### PR TITLE
Defines an interface to the Task Scheduler node

### DIFF
--- a/rmf_task_scheduler_msgs/CMakeLists.txt
+++ b/rmf_task_scheduler_msgs/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.8)
+project(rmf_task_scheduler_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/TaskScheduleRequest.msg"
+  "msg/TaskScheduleCancel.msg"
+  "msg/TaskScheduleResponse.msg"
+  "msg/TaskScheduleRule.msg"
+  "msg/TaskScheduleRules.msg"
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rmf_task_scheduler_msgs/msg/TaskScheduleCancel.msg
+++ b/rmf_task_scheduler_msgs/msg/TaskScheduleCancel.msg
@@ -1,0 +1,1 @@
+uint32 request_id

--- a/rmf_task_scheduler_msgs/msg/TaskScheduleRequest.msg
+++ b/rmf_task_scheduler_msgs/msg/TaskScheduleRequest.msg
@@ -16,4 +16,4 @@ builtin_interfaces/Duration repeat_interval
 string task_type
 
 # Task arguments
-string args
+string task_description

--- a/rmf_task_scheduler_msgs/msg/TaskScheduleRequest.msg
+++ b/rmf_task_scheduler_msgs/msg/TaskScheduleRequest.msg
@@ -1,15 +1,16 @@
 # Name of the rule
 string name
 
-# Days when the rule should be run
-string[] days_of_week
-
 # Start time
 builtin_interfaces/Time start_time
 
 # End time
 bool has_end_time
 builtin_interfaces/Time end_time
+
+# Repeat Interval
+bool has_repeat_interval
+builtin_interfaces/Duration repeat_interval
 
 # Task type
 string task_type

--- a/rmf_task_scheduler_msgs/msg/TaskScheduleRequest.msg
+++ b/rmf_task_scheduler_msgs/msg/TaskScheduleRequest.msg
@@ -1,0 +1,18 @@
+# Name of the rule
+string name
+
+# Days when the rule should be run
+string[] days_of_week
+
+# Start time
+builtin_interfaces/Time start_time
+
+# End time
+bool has_end_time
+builtin_interfaces/Time end_time
+
+# Task type
+string task_type
+
+# Task arguments
+string args

--- a/rmf_task_scheduler_msgs/msg/TaskScheduleResponse.msg
+++ b/rmf_task_scheduler_msgs/msg/TaskScheduleResponse.msg
@@ -1,0 +1,1 @@
+uint32 request_id

--- a/rmf_task_scheduler_msgs/msg/TaskScheduleRule.msg
+++ b/rmf_task_scheduler_msgs/msg/TaskScheduleRule.msg
@@ -1,0 +1,2 @@
+uint32 request_id
+TaskScheduleRequest request

--- a/rmf_task_scheduler_msgs/msg/TaskScheduleRules.msg
+++ b/rmf_task_scheduler_msgs/msg/TaskScheduleRules.msg
@@ -1,0 +1,1 @@
+TaskScheduleRule[] rules

--- a/rmf_task_scheduler_msgs/package.xml
+++ b/rmf_task_scheduler_msgs/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rmf_task_scheduler_msgs</name>
+  <version>0.0.0</version>
+  <description>A set of messages which </description>
+  <maintainer email="arjo@openrobotics.org">Arjo Chakravarty</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_default_generator</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Defines an interface to the Task Scheduler node

### Implemented feature

This PR introduces messages for the Web API to talk to the task scheduler node as defined in open-rmf/rmf_ros2#103

### Implementation description

A task can be submitted for a later time and it can be repeated at fixed intervals. Note that we use the time which RMF is running in. I'm not to sure how discrepancy between client time and server time is being handled right now (or if it needs to be handled at all).
