### PR TITLE
python module for rmf_api_msgs schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__
+build
+.vscode
+
+# temp file during py mod generation, Note: have this is /build?
+rmf_api_msgs/rmf_api_msgs/schemas.py
+
+# Executables
+*.exe
+*.out
+*.app

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 
 # temp file during py mod generation, Note: have this is /build?
 rmf_api_msgs/rmf_api_msgs/schemas.py
+rmf_api_msgs/rmf_api_msgs/models/*
 
 # Executables
 *.exe

--- a/.internal_tools/check_samples/src/main.rs
+++ b/.internal_tools/check_samples/src/main.rs
@@ -11,15 +11,17 @@ fn generate_schema_file_map(schema_directory: &str) -> HashMap<String, String> {
     for entry in std::fs::read_dir(&schema_directory).unwrap() {
         let file = entry.unwrap();
         map.insert(file.path().file_prefix().unwrap().to_str().unwrap().to_string(), file.path().to_str().unwrap().to_string());
-    }
-
+        let idx = file.path().file_prefix().unwrap().to_str().unwrap().to_string();
+        let ele = file.path().to_str().unwrap().to_string();
+        println!("file: {}  -> {}", idx, ele);
+    }   
     return map;
 }
 
 fn check_samples(schema_directory: &str, sample_directory: &str, options: CompilationOptions) -> bool {
 
     let schema_file_map = generate_schema_file_map(&schema_directory);
-
+    println!("---------------------------------------\n");
     let mut error_found = false;
     for subdirectory_entry in std::fs::read_dir(&sample_directory).unwrap() {
         let subdirectory = subdirectory_entry.unwrap().path();
@@ -34,6 +36,9 @@ fn check_samples(schema_directory: &str, sample_directory: &str, options: Compil
                     for entry in std::fs::read_dir(&subdirectory).unwrap() {
                         let sample_file = entry.unwrap();
                         let sample_str = std::fs::read_to_string(&sample_file.path()).unwrap();
+                        println!("##############################\n sample file: {} with {} ->\n {}",
+                                 sample_file.path().to_str().unwrap(), schema_path, sample_str);
+
                         let sample: Value = serde_json::from_str(&sample_str).unwrap();
                         let validation = validator.validate(&sample);
                         if let Err(errors) = validation {

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ colcon build --packages-select rmf_api_msgs
 source install/setup.bash
 ```
 
+Subsequently, to access the schemas, the user just needs to include/import the cpp header or py module into their source code.
+
 1. C++ example:
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Collection of json message schemas which bridges the C++ and python components o
 
 # Usage
 
+Download pkg for python model generation
+```bash
+pip3 install datamodel-code-generator
+```
+
 Compile with [colcon](https://colcon.readthedocs.io/en/released/) is recommended
 
 ```bash
@@ -25,6 +30,12 @@ nlohmann::json schema = rmf_api_msgs::schemas::task_state
 
 ```py
 from rmf_api_msgs import schemas
+from rmf_api_msgs.models import task_state
 
+# get schema
 schema = schemas.task_state()
+
+# create task_state model
+booking = task_state.Booking(id = "id0001")
+task_state = task_state.TaskState(booking = booking)
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # rmf_api_msgs
-Collection of messages which bridges the C++ components of RMF to the web interface
+
+Collection of json message schemas which bridges the C++ and python components of RMF to the web interface
+
+# Usage
+
+Compile with [colcon](https://colcon.readthedocs.io/en/released/) is recommended
+
+```bash
+colcon build --packages-select rmf_api_msgs
+source install/setup.bash
+```
+
+1. C++ example:
+
+```cpp
+#include <rmf_api_msgs/schemas/task_state.hpp>
+
+nlohmann::json schema = rmf_api_msgs::schemas::task_state
+```
+
+1. Python example:
+
+```py
+from rmf_api_msgs import schemas
+
+schema = schemas.task_state()
+```

--- a/rmf_api_msgs/CMakeLists.txt
+++ b/rmf_api_msgs/CMakeLists.txt
@@ -84,9 +84,28 @@ install(
 # Generate python schemas mode whenever colcon is triggered
 message(" Generating schema as py mods")
 ADD_CUSTOM_TARGET(
-  do_always ALL
+  py_schemas_gen ALL
   COMMAND python3 generate_py_schemas.py -p ${CMAKE_CURRENT_LIST_DIR}
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/scripts)
+
+# Generate pydantic models according to schemas
+# If datamodel-codegen not avail, then skip this proccess along with warning
+find_program(PY_MODELGEN_AVAIL datamodel-codegen)
+message("program is avail? " ${PY_MODELGEN_AVAIL})
+if(PY_MODELGEN_AVAIL)
+  message(" Generating py models with 'datamodel-codegen'")
+  ADD_CUSTOM_TARGET(
+    py_models_gen ALL
+    COMMAND eval "datamodel-codegen \
+      --disable-timestamp \
+      --input-file-type jsonschema  \
+      --input ${CMAKE_CURRENT_LIST_DIR}/schemas \
+      --output ${CMAKE_CURRENT_LIST_DIR}/rmf_api_msgs/models"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/scripts)
+else()
+  message(
+    WARNING "Not able to generate py models since 'datamodel-codegen' is not avail")
+endif()
 
 # Install Python modules
 ament_python_install_package(${PROJECT_NAME})

--- a/rmf_api_msgs/CMakeLists.txt
+++ b/rmf_api_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 include(GNUInstallDirs)
 
+find_package(ament_cmake REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
 include(cmake/rmf_api_generate_schema_headers.cmake)
@@ -79,3 +80,21 @@ install(
   DIRECTORY schemas
   DESTINATION ${CMAKE_INSTALL_DATADIR}
 )
+
+# Generate python schemas mode whenever colcon is triggered
+message(" Generating schema as py mods")
+ADD_CUSTOM_TARGET(
+  do_always ALL
+  COMMAND python3 generate_py_schemas.py -p ${CMAKE_CURRENT_LIST_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/scripts)
+
+# Install Python modules
+ament_python_install_package(${PROJECT_NAME})
+
+# # Install Python executables
+install(PROGRAMS
+  scripts/check_sample.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/rmf_api_msgs/CMakeLists.txt
+++ b/rmf_api_msgs/CMakeLists.txt
@@ -85,7 +85,10 @@ install(
 message(" Generating schema as py mods")
 ADD_CUSTOM_TARGET(
   py_schemas_gen ALL
-  COMMAND python3 generate_py_schemas.py -p ${CMAKE_CURRENT_LIST_DIR}
+  COMMAND eval "python3 generate_py_schemas.py \
+    --template_file ${CMAKE_CURRENT_LIST_DIR}/scripts/schemas_template.jinja2 \
+    --schemas_dir ${CMAKE_CURRENT_LIST_DIR}/schemas \
+    --output_file ${CMAKE_CURRENT_LIST_DIR}/rmf_api_msgs/schemas.py"
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/scripts)
 
 # Generate pydantic models according to schemas

--- a/rmf_api_msgs/CMakeLists.txt
+++ b/rmf_api_msgs/CMakeLists.txt
@@ -94,6 +94,7 @@ ament_python_install_package(${PROJECT_NAME})
 # # Install Python executables
 install(PROGRAMS
   scripts/check_sample.py
+  scripts/generate_py_schemas.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rmf_api_msgs/package.xml
+++ b/rmf_api_msgs/package.xml
@@ -9,8 +9,12 @@
   <license>Apache License 2.0</license>
 
   <depend>nlohmann-json3-dev</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>python3-jinja2</exec_depend>
+  <exec_depend>python3-jsonschema</exec_depend>
 
   <export>
-    <build_type>cmake</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/rmf_api_msgs/package.xml
+++ b/rmf_api_msgs/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>python3-jinja2</exec_depend>
   <exec_depend>python3-jsonschema</exec_depend>
+  <exec_depend>python3-pydantic</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_api_msgs/scripts/check_sample.py
+++ b/rmf_api_msgs/scripts/check_sample.py
@@ -16,8 +16,8 @@
 
 """
 This simple schema validation script shows a simple example of validating
-json input with the existing "task_state" and "task_logs" schemas in
-rmf_api_msgs.
+json input with the existing "task_state" and "task_logs" schemas, 
+defined in rmf_api_msgs.
 """
 
 import json
@@ -27,39 +27,41 @@ import argparse
 from jsonschema import validate
 from rmf_api_msgs import schemas
 
+
 def main(argv=None):
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--task_log", action="store_true",
-                      help='validate task log')
-  parser.add_argument("--task_state", action="store_true",
-                      help='validate task state')
-  parser.add_argument('-i', '--input', required=True,
-                      type=str, help='json file input path')
-  args = parser.parse_args(argv[1:])
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--task_log", action="store_true",
+                        help='validate task log')
+    parser.add_argument("--task_state", action="store_true",
+                        help='validate task state')
+    parser.add_argument('-i', '--input', required=True,
+                        type=str, help='json file input path')
+    args = parser.parse_args(argv[1:])
 
-  if args.task_state:
-    print("checking input json with [task_state] schema")
-    schema = schemas.task_state()
-  elif args.task_log:
-    print("checking input json with [task_log] schema")
-    schema = schemas.task_log()
-  else:
-    print("Error, No schema selection is chosen, exit")
-    parser.print_help()
-    exit(0)
+    if args.task_state:
+        print("checking input json with [task_state] schema")
+        schema = schemas.task_state()
+    elif args.task_log:
+        print("checking input json with [task_log] schema")
+        schema = schemas.task_log()
+    else:
+        print("Error, No schema selection is chosen, exit")
+        parser.print_help()
+        exit(0)
 
-  schema = json.loads(schema)
+    schema = json.loads(schema)
 
-  # load input file
-  file = open(args.input)
-  data = json.load(file)
-  file.close()
+    # load input file
+    file = open(args.input)
+    data = json.load(file)
+    file.close()
 
-  error = validate(instance=data, schema=schema)
-  if not error:
-    print(f"Validated [{args.input}]. It's Good!")
+    error = validate(instance=data, schema=schema)
+    if not error:
+        print(f"Validated [{args.input}]. It's Good!")
 
 ###############################################################################
 
+
 if __name__ == "__main__":
-  main(sys.argv)
+    main(sys.argv)

--- a/rmf_api_msgs/scripts/check_sample.py
+++ b/rmf_api_msgs/scripts/check_sample.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This simple schema validation script shows a simple example of validating
+json input with the existing "task_state" and "task_logs" schemas in
+rmf_api_msgs.
+"""
+
+import json
+import sys
+import argparse
+
+from jsonschema import validate
+from rmf_api_msgs import schemas
+
+def main(argv=None):
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--task_log", action="store_true",
+                      help='validate task log')
+  parser.add_argument("--task_state", action="store_true",
+                      help='validate task state')
+  parser.add_argument('-i', '--input', required=True,
+                      type=str, help='json file input path')
+  args = parser.parse_args(argv[1:])
+
+  if args.task_state:
+    print("checking input json with [task_state] schema")
+    schema = schemas.task_state()
+  elif args.task_log:
+    print("checking input json with [task_log] schema")
+    schema = schemas.task_log()
+  else:
+    print("Error, No schema selection is chosen, exit")
+    parser.print_help()
+    exit(0)
+
+  schema = json.loads(schema)
+
+  # load input file
+  file = open(args.input)
+  data = json.load(file)
+  file.close()
+
+  error = validate(instance=data, schema=schema)
+  if not error:
+    print(f"Validated [{args.input}]. It's Good!")
+
+###############################################################################
+
+if __name__ == "__main__":
+  main(sys.argv)

--- a/rmf_api_msgs/scripts/generate_py_schemas.py
+++ b/rmf_api_msgs/scripts/generate_py_schemas.py
@@ -31,17 +31,16 @@ def main(argv=None):
     script locally for pkg installation.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--pkg_dir', required=True,
-                        type=str, help='rmf_api_msgs pkg dir')
+    parser.add_argument('-tf', '--template_file', required=True, type=str,
+                        help='path for schemas template file in .jinja2')
+    parser.add_argument('-sd', '--schemas_dir', required=True, type=str,
+                        help='input directory with *.json schemas files')
+    parser.add_argument('-o', '--output_file', default="schemas.py", type=str,
+                        help='output schema script path, default: schemas.py')
     args = parser.parse_args(argv[1:])
 
-    # collections of file paths for IO
-    template_path = f'{args.pkg_dir}/scripts/schemas_template.jinja2'
-    schemas_files_dir = f'{args.pkg_dir}/schemas/*.json'
-    output_script_path = f'{args.pkg_dir}/rmf_api_msgs/schemas.py'
-
-    # open template
-    file = open(template_path)
+    # open template file path
+    file = open(args.template_file)
     schema_template = file.read()
     file.close()
 
@@ -49,7 +48,7 @@ def main(argv=None):
     print("py template for json schema is loaded, now load json schemas... \n")
 
     # get all json schemas filenames in the target dir
-    file_paths = glob.glob(schemas_files_dir)
+    file_paths = glob.glob(f"{args.schemas_dir}/*.json")
     print(" - Target Schemas: ", [os.path.basename(x) for x in file_paths])
 
     # Create json string
@@ -66,9 +65,9 @@ def main(argv=None):
 
     output_script = t.render(schemas_dict=schemas_dict)
 
-    with open(output_script_path, 'w') as f:
+    with open(args.output_file, 'w') as f:
         f.write(output_script)
-        print(f" py schemas module is created: {output_script_path}")
+        print(f" py schemas module is created: {args.output_file}")
 
     print("\n Done with py schema modules generation!")
 

--- a/rmf_api_msgs/scripts/generate_py_schemas.py
+++ b/rmf_api_msgs/scripts/generate_py_schemas.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+import argparse
+
+from jinja2 import Template
+import glob
+
+###############################################################################
+
+
+def main(argv=None):
+    """
+    This will load schema_template, and a list of schemas, then generate and 
+    output a schemas.py script locally for pkg installation.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--pkg_dir', required=True,
+                    type=str, help='rmf_api_msgs pkg dir')
+    args = parser.parse_args(argv[1:])
+    pkg_dir = args.pkg_dir
+
+    # open template
+    file = open(f"{pkg_dir}/scripts/schemas_template.jinja2")
+    schema_template = file.read()
+    file.close()
+
+    t = Template(schema_template)
+    print("py template for json schema is loaded, now load json schemas... \n")
+
+    # get all json schemas filenames in the target dir
+    filenames = [
+        os.path.basename(x) for x in glob.glob(f"{pkg_dir}/schemas/*.json")
+    ]
+
+    print(" - Target Schemas: " , filenames)
+
+    # Create json string
+    schemas_dict = {}
+    for file_name in filenames:
+        file = open(f"{pkg_dir}/schemas/{file_name}")
+        json_body = (file.read())
+        file.close()
+        mod_name = os.path.splitext(file_name)[0]
+        schemas_dict[mod_name] = json_body
+
+    output_script = t.render(schemas_dict=schemas_dict)
+
+    with open(f'{pkg_dir}/rmf_api_msgs/schemas.py', 'w') as f:
+        f.write(output_script)
+
+    print("\n Done with py schema modules generation!")
+
+
+###############################################################################
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/rmf_api_msgs/scripts/schemas_template.jinja2
+++ b/rmf_api_msgs/scripts/schemas_template.jinja2
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+###############################################################################
+# This python module is a self generated script from 
+# rmf_api_msgs/scripts/schema_template.py.t
+
+import os
+
+{% for name in schemas_dict -%}
+###############################################################################
+# @Brief: Function to get {{ name }} json schema
+# @return: json schema, in raw string
+def {{ name }}():
+    return r"""
+{{ schemas_dict[name] }}"""
+
+{% endfor %}

--- a/rmf_api_msgs/scripts/schemas_template.jinja2
+++ b/rmf_api_msgs/scripts/schemas_template.jinja2
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 ###############################################################################
 # This python module is a self generated script from 
-# rmf_api_msgs/scripts/schema_template.py.t
+# rmf_api_msgs/scripts/schemas_template.jinja2
 
 import os
 


### PR DESCRIPTION
The objective here is to make the `rmf_api_msgs` schemas and data models available to users as a python package. Similar to the existing cpp header generation, the schemas here are generated as python functions. After compilation, users can obtain the schemas and data models by just importing the `rmf_api_msgs` python module.

### Description
- During compilation of `rmf_api_msgs` pkg, cmakelist will run 2 commands to generate the python `rmf_api_msgs.schemas` and `rmf_api_msgs.models`:
- **rmf_api_msgs.schemas**
  - Execute `generate_py_schemas.py`. It will load all existing `/schemas/*.json`, and generate `schemas.py` according to the template: `schemas_template.jinja2`
- **rmf_api_msgs.models**:
  - This depends on an external datamodel generation pkg: [data-model-codegen](https://github.com/koxudaxi/datamodel-code-generator)
  - `data-model-codegen` script will generate respective data models according to the schemas. The output is located at `rmf_api_msgs/rmf_api_msgs/models/*`
- Lastly, `ament_python_install_package()` in the cmakelist will install the `rmf_api_msgs` module
- The implementation here is very experimental, not sure if this is the "right way" to generate py schemas and models.
- [NOT RELEVANT] Also, added some minor printout in rust scripts for verbosity, greatly help in debugging

###  To Test
To view the python modules:
```bash
colcon build --packages-select rmf_api_msgs
source install.setup
python3
>>> import rmf_api_msgs.schemas as schemas
>>> from rmf_api_msgs.models import task_state
>>> help(schemas)
>>> help(task_state)
```

Simple validation script in py:
```bash
ros2 run rmf_api_msgs check_sample.py -i src/rmf_api_msgs/rmf_api_msgs/samples/task_log/multi_dropoff_delivery.json --task_log
```
**Maybe shouldn't depend on  `ament_cmake` here??


Feedback is more than welcome.
