### PR TITLE
rtls Json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Subsequently, to access the schemas, the user just needs to include/import the c
 nlohmann::json schema = rmf_api_msgs::schemas::task_state
 ```
 
-1. Python example:
+2. Python example:
 
 ```py
 from rmf_api_msgs import schemas

--- a/rmf_api_msgs/CMakeLists.txt
+++ b/rmf_api_msgs/CMakeLists.txt
@@ -86,7 +86,6 @@ message(" Generating schema as py mods")
 ADD_CUSTOM_TARGET(
   py_schemas_gen ALL
   COMMAND eval "python3 generate_py_schemas.py \
-    --template_file ${CMAKE_CURRENT_LIST_DIR}/scripts/schemas_template.jinja2 \
     --schemas_dir ${CMAKE_CURRENT_LIST_DIR}/schemas \
     --output_file ${CMAKE_CURRENT_LIST_DIR}/rmf_api_msgs/schemas.py"
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/scripts)
@@ -94,7 +93,6 @@ ADD_CUSTOM_TARGET(
 # Generate pydantic models according to schemas
 # If datamodel-codegen not avail, then skip this proccess along with warning
 find_program(PY_MODELGEN_AVAIL datamodel-codegen)
-message("program is avail? " ${PY_MODELGEN_AVAIL})
 if(PY_MODELGEN_AVAIL)
   message(" Generating py models with 'datamodel-codegen'")
   ADD_CUSTOM_TARGET(
@@ -113,9 +111,10 @@ endif()
 # Install Python modules
 ament_python_install_package(${PROJECT_NAME})
 
-# # Install Python executables
+# # Install Python executables and share template
 install(PROGRAMS
   scripts/check_sample.py
+  scripts/schemas_template.jinja2
   scripts/generate_py_schemas.py
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/rmf_api_msgs/package.xml
+++ b/rmf_api_msgs/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="youliang@openrobotics.org">You Liang</maintainer>
   <license>Apache License 2.0</license>
 
-  <depend>nlohmann-json3-dev</depend>
+  <depend>nlohmann-json-dev</depend>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>python3-jinja2</exec_depend>

--- a/rmf_api_msgs/schemas/rtls_tag_state.json
+++ b/rmf_api_msgs/schemas/rtls_tag_state.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/rtls_tag_state.json",
+  "title": "Rtls Tag State",
+  "description": "The state of a realtime location system tag",
+  "type": "object",
+  "properties": {
+    "tag_id": {
+      "description": "The ID of the rtls tag.",
+      "type": "string"
+    },
+    "status": {
+      "description": "A simple token representing the status of the tag",
+      "type": "string",
+      "enum": ["uninitialized", "offline", "shutdown", "idle", "charging", "working", "error"]
+    },
+    "location_type": {
+      "description": "The type location information provided by the tag.",
+      "type": "string",
+      "enum": ["zone", "coord"]
+    },
+    "asset_type": {
+      "description": "The type of the tagged asset.",
+      "type": "object",
+      "properties": {
+        "asset_type": {
+          "description": "type of the asset",
+          "type": "string"
+        },
+        "asset_subtype": {
+          "description": "subtype of the asset",
+          "type": "string"
+        }
+      },
+      "required": ["type", "subtype"]
+    },
+    "unix_millis_time": { "type": "integer" },
+    "location": { "$ref": "location_2D.json" },
+    "battery": {
+      "description": "State of charge of the battery. Values range from 0.0 (depleted) to 1.0 (fully charged)",
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "issues": {
+      "description": "A list of issues with the tag that operators need to address",
+      "type": "array",
+      "items": { "$ref": "#/$defs/issue" }
+    }
+  },
+  "required": ["tag_id"],
+  "$defs": {
+    "issue": {
+      "description": "An issue that an operator needs to respond to (e.g. disconnection, lost)",
+      "type": "object",
+      "properties": {
+        "category": {
+          "description": "Category of the tag's issue",
+          "type": "string"
+        },
+        "detail": {
+          "description": "Detailed information about the issue",
+          "anyOf": [
+            { "type": "object" },
+            { "type": "array" },
+            { "type": "string" }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/rmf_api_msgs/schemas/transformation_2D.json
+++ b/rmf_api_msgs/schemas/transformation_2D.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/transformation_2D.json",
+  "title": "Transformation 2D",
+  "description": "Transformation between 2 maps",
+  "type": "object",
+  "properties": {
+    "target_map": { "type": "string" },
+    "ref_map": { "type": "string" },
+    "x": { "type": "number" },
+    "y": { "type": "number" },
+    "yaw": { "type": "number" },
+    "scale": { "type": "number" }
+  },
+  "required": ["target_map", "ref_map", "x", "y", "yaw", "scale"]
+}

--- a/rmf_api_msgs/scripts/generate_py_schemas.py
+++ b/rmf_api_msgs/scripts/generate_py_schemas.py
@@ -30,14 +30,23 @@ def main(argv=None):
     According to the jinja2 py template, it will then generate a schemas.py
     script locally for pkg installation.
     """
+    script_path = os.path.dirname(os.path.realpath(__file__)) # script dir
+
     parser = argparse.ArgumentParser()
-    parser.add_argument('-tf', '--template_file', required=True, type=str,
-                        help='path for schemas template file in .jinja2')
     parser.add_argument('-sd', '--schemas_dir', required=True, type=str,
                         help='input directory with *.json schemas files')
     parser.add_argument('-o', '--output_file', default="schemas.py", type=str,
                         help='output schema script path, default: schemas.py')
+    parser.add_argument('-tf', '--template_file', type=str,
+                        default=f"{script_path}/schemas_template.jinja2",
+                        help=f'path of custom template .jinja2 file, \
+                            default: [{script_path}/schemas_template.jinja2]')
     args = parser.parse_args(argv[1:])
+
+    # directory and path check
+    if not os.path.exists(args.template_file):
+        print(f"template file: {args.template_file} doesnt exist")
+        exit(1)
 
     # open template file path
     file = open(args.template_file)
@@ -67,7 +76,7 @@ def main(argv=None):
 
     with open(args.output_file, 'w') as f:
         f.write(output_script)
-        print(f" py schemas module is created: {args.output_file}")
+        print(f" py schemas module is created: [{args.output_file}]")
 
     print("\n Done with py schema modules generation!")
 


### PR DESCRIPTION
These json schemas are used by the `rmf_rtls` web server.  https://github.com/open-rmf/rmf_rtls/pull/1. The format of the schema will dictate RestApi endpoints msg structure in `rtls_server` .

- `rmf_api_msgs/schemas/rtls_tag_state.json`
- `rmf_api_msgs/schemas/transformation_2D.json`

Note: Since this pr is using the pydantic generation feature in https://github.com/open-rmf/rmf_api_msgs/pull/9, this pr will need to be in sync with the aforementioned pr.