### PR TITLE
Fix nlohmann::json dependency

### DIFF
--- a/rmf_api_msgs/package.xml
+++ b/rmf_api_msgs/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="youliang@openrobotics.org">You Liang</maintainer>
   <license>Apache License 2.0</license>
 
-  <depend>nlohmann-json3-dev</depend>
+  <depend>nlohmann-json-dev</depend>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>python3-jinja2</exec_depend>


### PR DESCRIPTION
`rosdep` key for `nlohmann-json3-dev` is `nlohmann-json-dev`.