### PR TITLE
Comment out pydantic library not there for rhel.

### DIFF
--- a/rmf_api_msgs/package.xml
+++ b/rmf_api_msgs/package.xml
@@ -13,7 +13,7 @@
 
   <exec_depend>python3-jinja2</exec_depend>
   <exec_depend>python3-jsonschema</exec_depend>
-  <exec_depend>python3-pydantic</exec_depend>
+<!--<exec_depend>python3-pydantic</exec_depend>-->
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
`python3-pydantic` is not there for `RHEL` and it will take a while until it can be made available. Since this seems to be an optional dependency I commented it out so this package can be made available in the meantime.
