### PR TITLE
some python deps seem to be needed at build time

### DIFF
--- a/rmf_api_msgs/package.xml
+++ b/rmf_api_msgs/package.xml
@@ -9,10 +9,10 @@
   <license>Apache License 2.0</license>
 
   <depend>nlohmann-json-dev</depend>
+  <depend>python3-jinja2</depend>
+  <depend>python3-jsonschema</depend>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>python3-jinja2</exec_depend>
-  <exec_depend>python3-jsonschema</exec_depend>
 <!--<exec_depend>python3-pydantic</exec_depend>-->
 
   <export>


### PR DESCRIPTION
Building this package seems to need these dependencies: https://build.ros2.org/view/Rbin_uJ64/job/Rbin_uJ64__rmf_api_msgs__ubuntu_jammy_amd64__binary/14/consoleFull#console-section-15

So moving them from `build-depend` to `depend` to fix the issue.

Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>
