### PR TITLE
fix FleetLog being named as `Fleet State`

### DIFF
--- a/rmf_api_msgs/schemas/fleet_log.json
+++ b/rmf_api_msgs/schemas/fleet_log.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/fleet_log.json",
-  "title": "Fleet State",
+  "title": "Fleet Log",
   "description": "The log of a fleet",
   "type": "object",
   "properties": {


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

Fix `FleetLog` being called `Fleet State` which causes code generators to conflict with the actual `Fleet State`.

I updated `rmf-web` with the fixed schemas based on this commit, so if it doesn't cause any problems, using normal merge (not squash) will save the trouble of not requiring a re-generate of the models.