### PR TITLE
Json schema for Favorite Task model

### DIFF
--- a/rmf_api_msgs/schemas/task_favorite.json
+++ b/rmf_api_msgs/schemas/task_favorite.json
@@ -11,12 +11,7 @@
       "priority": { "type": "object" },
       "category": { "type": "string" },
       "description": {
-        "description": "A description of the task. Task properties by category",
-        "anyOf": [
-          { "type": "object" },
-          { "type": "array" },
-          { "type": "string" }
-        ]
+        "description": "A description of the task. Task properties by category"
       },
       "user": { "type": "string" }
     },

--- a/rmf_api_msgs/schemas/task_favorite.json
+++ b/rmf_api_msgs/schemas/task_favorite.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/task_favorite.json",
+    "title": "Task Favorite",
+    "description": "A favorite task",
+    "type": "object",
+    "properties": {
+      "id": { "type": "string" },
+      "name": { "description": "The favorite name", "type": "string" },
+      "unix_millis_earliest_start_time": { "type": "integer" },
+      "priority": { "type": "object" },
+      "category": { "type": "string" },
+      "description": {
+        "description": "A description of the task. Task properties by category",
+        "anyOf": [
+          { "type": "object" },
+          { "type": "array" },
+          { "type": "string" }
+        ]
+      },
+      "user": { "type": "string" }
+    }
+  }
+  

--- a/rmf_api_msgs/schemas/task_favorite.json
+++ b/rmf_api_msgs/schemas/task_favorite.json
@@ -19,6 +19,7 @@
         ]
       },
       "user": { "type": "string" }
-    }
+    },
+    "required": ["name", "category", "description"]
   }
   

--- a/rmf_api_msgs/schemas/task_favorite_request.json
+++ b/rmf_api_msgs/schemas/task_favorite_request.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/task_favorite_request.json",
+    "title": "Task Favorite Request",
+    "type": "object",
+    "properties": {
+      "type": {
+        "description": "Indicate that this is a task favorite request",
+        "type": "string",
+        "enum": ["task_favorite_request"]
+      },
+      "request": { "$ref": "task_favorite.json" }
+    },
+    "required": ["type", "request"]
+  }
+  

--- a/rmf_api_msgs/schemas/task_favorite_response.json
+++ b/rmf_api_msgs/schemas/task_favorite_response.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/task_favorite_response.json",
+    "title": "Task Favorite Response",
+    "description": "Response to a task favorite request",
+    "type": "object",
+    "oneOf": [
+      {
+        "properties": {
+          "success": { "type": "boolean", "enum": [true] },
+          "data": { "$ref": "task_favorite.json" }
+        },
+        "required": ["success", "data"]
+      },
+      {
+        "properties": {
+          "success": { "type": "boolean", "enum": [false] },
+          "errors": {
+            "description": "Any error messages explaining why the request failed",
+            "type": "array",
+            "items": { "$ref": "error.json" }
+          }
+        }
+      }
+    ]
+  }
+  


### PR DESCRIPTION
New schemas have been added. 
Those schemas allow generate file.py in [rmf_web](https://github.com/open-rmf/rmf-web/tree/main/packages/api-server/api_server/models/rmf_api)
- rmf_api_msgs/schemas/task_favorite.json
- rmf_api_msgs/schemas/task_favorite_request.json
- rmf_api_msgs/schemas/task_favorite_response.json

