### PR TITLE
Task request time and initiator in task request

### DIFF
--- a/rmf_api_msgs/schemas/task_request.json
+++ b/rmf_api_msgs/schemas/task_request.json
@@ -26,7 +26,7 @@
       "type": "array",
       "items": { "type": "string" }
     },
-    "initiator": {
+    "requester": {
       "description": "(Optional) An identifier for the entity that requested this task",
       "type": "string"
     }

--- a/rmf_api_msgs/schemas/task_request.json
+++ b/rmf_api_msgs/schemas/task_request.json
@@ -9,6 +9,10 @@
       "description": "(Optional) The earliest time that this task may start",
       "type": "integer"
     },
+    "unix_millis_request_time": {
+      "description": "(Optional) The time that this request was initiated",
+      "type": "integer"
+    },
     "priority": {
       "description": "(Optional) The priority of this task. This must match a priority schema supported by a fleet.",
       "type": "object"
@@ -21,6 +25,10 @@
       "description": "Labels to describe the purpose of the task dispatch request",
       "type": "array",
       "items": { "type": "string" }
+    },
+    "initiator": {
+      "description": "(Optional) An identifier for the entity that requested this task",
+      "type": "string"
     }
   },
   "required": ["category", "description"]

--- a/rmf_api_msgs/schemas/task_state.json
+++ b/rmf_api_msgs/schemas/task_state.json
@@ -116,6 +116,7 @@
           "type": "string"
         },
         "unix_millis_earliest_start_time": { "type": "integer" },
+        "unix_millis_request_time": { "type": "integer" },
         "priority": {
           "description": "Priority information about this task",
           "anyOf": [
@@ -127,6 +128,10 @@
           "description": "Information about how and why this task was booked",
           "type": "array",
           "items": { "type": "string" }
+        },
+        "initiator": {
+          "description": "Task initiator",
+          "type": "string"
         }
       },
       "required": ["id"]

--- a/rmf_api_msgs/schemas/task_state.json
+++ b/rmf_api_msgs/schemas/task_state.json
@@ -129,8 +129,8 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "initiator": {
-          "description": "Task initiator",
+        "requester": {
+          "description": "(Optional) An identifier for the entity that requested this task",
           "type": "string"
         }
       },


### PR DESCRIPTION
## New feature implementation

### Implemented feature

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

* Adds the optional fields of request start time and initiator
* This is required by https://github.com/open-rmf/rmf-web/pull/702 and the mentioned PRs, to add more information on the task queue of rmf-web