### PR TITLE
Switch to rst changelog

### DIFF
--- a/rmf_api_msgs/CHANGELOG.md
+++ b/rmf_api_msgs/CHANGELOG.md
@@ -1,5 +1,0 @@
-## Changelog for package rmf_api_msgs
-
-0.0.1 (2022-02-14)
-------------------
-* Introduce public web API for RMF

--- a/rmf_api_msgs/CHANGELOG.rst
+++ b/rmf_api_msgs/CHANGELOG.rst
@@ -1,0 +1,7 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rmf_api_msgs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.0.1 (2022-02-14)
+------------------
+* Introduce public web API for RMF


### PR DESCRIPTION
This is to align with [REP 132](https://www.ros.org/reps/rep-0132.html) and will greatly improve the ease of updating changelogs in the future as they will be auto-populated when running [catkin_generate_changelog](https://docs.ros.org/en/rolling/How-To-Guides/Releasing/Subsequent-Releases.html#updating-changelog)

> Note: The `CHANGELOG.rst` was autogenerated from the existing `CHANGELOG.md` using [catkin_md2rst_changelog](https://github.com/Yadunund/catkin_pkg/blob/yadu/md2rst/src/catkin_pkg/cli/md2rst_changelog.py)