### PR TITLE
Introduce schemas for robot commission request

### DIFF
--- a/rmf_api_msgs/schemas/commission.json
+++ b/rmf_api_msgs/schemas/commission.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/commission.json",
+  "title": "Commission",
+  "description": "Describe the commission of a robot. Used in a request, this describes desired changes to the current commission.",
+  "type": "object",
+  "properties": {
+    "dispatch_tasks": {
+      "description": "Should the robot accept dispatched tasks, true/false. When used in a request, leave this unset to not change the robot's current value.",
+      "type": "boolean"
+    },
+    "direct_tasks": {
+      "description": "Should the robot accept direct task requests, true/false. When used in a request, leave this unset to not change the robot's current value.",
+      "type": "boolean"
+    },
+    "idle_behavior": {
+      "description": "Should the robot perform its idle behavior, true/false. When used in a request, leave this unset to not change the robot's current value.",
+      "type": "boolean"
+    }
+  }
+}

--- a/rmf_api_msgs/schemas/robot_commission_request.json
+++ b/rmf_api_msgs/schemas/robot_commission_request.json
@@ -8,7 +8,7 @@
     "type": {
       "description": "Indicate that this is a robot commission request",
       "type": "string",
-      "constant": "commission_request"
+      "constant": "robot_commission_request"
     },
     "robot": {
       "description": "The name of the robot",

--- a/rmf_api_msgs/schemas/robot_commission_request.json
+++ b/rmf_api_msgs/schemas/robot_commission_request.json
@@ -19,9 +19,15 @@
       "type": "string"
     },
     "commission": { "$ref": "commission.json" },
-    "reassign_tasks": {
-      "description": "Should the tasks of the decommissioned robot be reassigned to other robots? If unset, it will be treated as true.",
-      "type": "boolean"
+    "pending_dispatch_tasks_policy": {
+      "description": "What should be done for pending dispatched tasks that were assigned to this robot? reassign: pending dispatched tasks will be reassigned to other robots in the fleet, or canceled if there are no more robots available. complete: the robot will complete its pending dispatched tasks. cancel: pending dispatched tasks will be immediately canceled. If unset, it will default to reassign.",
+      "type": "string",
+      "enum": ["reassign", "complete", "cancel"]
+    },
+    "pending_direct_tasks_policy": {
+      "description": "Set the behavior for what should happen with the pending direct task assignments of a robot. complete: pending direct tasks will be completed. canceled: pending direct tasks will be immediately canceled. If unset, it will default to complete.",
+      "type": "string",
+      "enum": ["complete", "cancel"]
     }
   },
   "required": ["type", "robot", "fleet", "commission"]

--- a/rmf_api_msgs/schemas/robot_commission_request.json
+++ b/rmf_api_msgs/schemas/robot_commission_request.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/robot_commission_request.json",
+  "title": "Robot Commission Request",
+  "description": "Request a change in the commission of a robot, i.e. whether it accepts dispatched and/or direct tasks",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Indicate that this is a robot commission request",
+      "type": "string",
+      "constant": "commission_request"
+    },
+    "robot": {
+      "description": "The name of the robot",
+      "type": "string"
+    },
+    "fleet": {
+      "description": "The fleet the robot belongs to",
+      "type": "string"
+    },
+    "commission": {
+      "description": "Describe the requested commission for this robot",
+      "type": "object",
+      "properties": {
+        "dispatch_tasks": {
+          "description": "Should the robot accept dispatched tasks, true/false. Leave unset to not change the robot's current value.",
+          "type": "boolean"
+        },
+        "direct_tasks": {
+          "description": "Should the robot accept direct task requests, true/false. Leave unset to not change the robot's current value.",
+          "type": "boolean"
+        },
+        "idle_behavior": {
+          "description": "Should the robot perform its idle behavior, true/false. Leave unset to not change the robot's current value.",
+          "type": "boolean"
+        }
+      }
+    },
+    "reassign_tasks": {
+      "description": "Should the tasks of the decommissioned robot be reassigned to other robots? If unset, it will be treated as true.",
+      "type": "boolean"
+    }
+  },
+  "required": ["type", "robot", "fleet", "commission"]
+}

--- a/rmf_api_msgs/schemas/robot_commission_request.json
+++ b/rmf_api_msgs/schemas/robot_commission_request.json
@@ -18,24 +18,7 @@
       "description": "The fleet the robot belongs to",
       "type": "string"
     },
-    "commission": {
-      "description": "Describe the requested commission for this robot",
-      "type": "object",
-      "properties": {
-        "dispatch_tasks": {
-          "description": "Should the robot accept dispatched tasks, true/false. Leave unset to not change the robot's current value.",
-          "type": "boolean"
-        },
-        "direct_tasks": {
-          "description": "Should the robot accept direct task requests, true/false. Leave unset to not change the robot's current value.",
-          "type": "boolean"
-        },
-        "idle_behavior": {
-          "description": "Should the robot perform its idle behavior, true/false. Leave unset to not change the robot's current value.",
-          "type": "boolean"
-        }
-      }
-    },
+    "commission": { "$ref": "commission.json" },
     "reassign_tasks": {
       "description": "Should the tasks of the decommissioned robot be reassigned to other robots? If unset, it will be treated as true.",
       "type": "boolean"

--- a/rmf_api_msgs/schemas/robot_commission_response.json
+++ b/rmf_api_msgs/schemas/robot_commission_response.json
@@ -4,22 +4,30 @@
   "title": "Robot Commission Response",
   "description": "Response to a robot commission request",
   "type": "object",
-  "oneOf": [
-    {
-      "properties": {
-        "success": { "type": "boolean", "enum": [true] }
-      },
-      "required": ["success"]
-    },
-    {
-      "properties": {
-        "success": { "type": "boolean", "enum": [false] },
-        "errors": {
-          "description": "Any error messages explaining why the request failed",
-          "type": "array",
-          "items": { "$ref": "error.json" }
+  "commission": { "$ref": "#/$defs/result" },
+  "pending_dispatch_tasks_policy": { "$ref": "#/$defs/result" },
+  "pending_direct_tasks_policy": { "$ref": "#/$defs/result" },
+  "$defs": {
+    "result": {
+      "oneOf": [
+        {
+          "properties": {
+            "success": { "type": "boolean", "enum": [true] }
+          },
+          "required": ["success"]
+        },
+        {
+          "properties": {
+            "success": { "type": "boolean", "enum": [false] },
+            "errors": {
+              "description": "Any error messages explaining why the request failed",
+              "type": "array",
+              "items": { "$ref": "error.json" }
+            }
+          },
+          "required": ["success"]
         }
-      }
+      ]
     }
-  ]
+  }
 }

--- a/rmf_api_msgs/schemas/robot_commission_response.json
+++ b/rmf_api_msgs/schemas/robot_commission_response.json
@@ -4,9 +4,11 @@
   "title": "Robot Commission Response",
   "description": "Response to a robot commission request",
   "type": "object",
-  "commission": { "$ref": "#/$defs/result" },
-  "pending_dispatch_tasks_policy": { "$ref": "#/$defs/result" },
-  "pending_direct_tasks_policy": { "$ref": "#/$defs/result" },
+  "properties": {
+    "commission": { "$ref": "#/$defs/result" },
+    "pending_dispatch_tasks_policy": { "$ref": "#/$defs/result" },
+    "pending_direct_tasks_policy": { "$ref": "#/$defs/result" }
+  },
   "$defs": {
     "result": {
       "oneOf": [

--- a/rmf_api_msgs/schemas/robot_commission_response.json
+++ b/rmf_api_msgs/schemas/robot_commission_response.json
@@ -9,6 +9,7 @@
     "pending_dispatch_tasks_policy": { "$ref": "#/$defs/result" },
     "pending_direct_tasks_policy": { "$ref": "#/$defs/result" }
   },
+  "required": ["commission"],
   "$defs": {
     "result": {
       "oneOf": [

--- a/rmf_api_msgs/schemas/robot_commission_response.json
+++ b/rmf_api_msgs/schemas/robot_commission_response.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_api_msgs/main/rmf_api_msgs/schemas/robot_commission_response.json",
+  "title": "Robot Commission Response",
+  "description": "Response to a robot commission request",
+  "type": "object",
+  "oneOf": [
+    {
+      "properties": {
+        "success": { "type": "boolean", "enum": [true] }
+      },
+      "required": ["success"]
+    },
+    {
+      "properties": {
+        "success": { "type": "boolean", "enum": [false] },
+        "errors": {
+          "description": "Any error messages explaining why the request failed",
+          "type": "array",
+          "items": { "$ref": "error.json" }
+        }
+      }
+    }
+  ]
+}

--- a/rmf_api_msgs/schemas/robot_state.json
+++ b/rmf_api_msgs/schemas/robot_state.json
@@ -27,7 +27,8 @@
       "description": "A list of issues with the robot that operators need to address",
       "type": "array",
       "items": { "$ref": "#/$defs/issue" }
-    }
+    },
+    "commission": { "$ref": "commission.json" }
   },
   "$defs": {
     "issue": {

--- a/rmf_api_msgs/schemas/robot_task_request.json
+++ b/rmf_api_msgs/schemas/robot_task_request.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "type": {
-      "description": "Indicate that this is a task dispatch request",
+      "description": "Indicate that this is a direct task request",
       "type": "string",
       "constant": "robot_task_request"
     },


### PR DESCRIPTION
A commission request feature is being added to `rmf_fleet_adapter` that will allow users to change the commissioning of a robot. Commissioning means whether the robot is willing to accept dispatched tasks or direct tasks. This will also allow the idle behavior of the robot to be toggled on and off.

These features will help operators to stop a robot from receiving any further tasks and reassign tasks that the robot already had in situations where the robot must be taken out of commission temporarily.