### PR TITLE
Add mutex group information to robot_state

### DIFF
--- a/rmf_api_msgs/schemas/robot_state.json
+++ b/rmf_api_msgs/schemas/robot_state.json
@@ -28,7 +28,23 @@
       "type": "array",
       "items": { "$ref": "#/$defs/issue" }
     },
-    "commission": { "$ref": "commission.json" }
+    "commission": { "$ref": "commission.json" },
+    "mutex_groups": {
+      "description": "Information about the mutex groups that this robot is interacting with",
+      "type": "object",
+      "properties": {
+        "locked": {
+          "description": "A list of mutex groups that this robot has currently locked",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "requesting": {
+          "description": "A list of the mutex groups that this robot is currently requesting but has not lockd yet",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
   },
   "$defs": {
     "issue": {


### PR DESCRIPTION
This adds mutex group information to the schema for `robot_state` as an optional field. If the field is missing from the `robot_state` message then that implies that the information isn't available from the fleet adapter that is currently running, not that no mutex groups are locked or requested.