### PR TITLE
Document how labels should be formatted

### DIFF
--- a/rmf_api_msgs/schemas/cancel_task_request.json
+++ b/rmf_api_msgs/schemas/cancel_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the cancellation",
+      "description": "Labels to describe the purpose of the cancellation, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/cancel_task_request.json
+++ b/rmf_api_msgs/schemas/cancel_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the cancellation, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the cancellation, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/cancel_task_request.json
+++ b/rmf_api_msgs/schemas/cancel_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the cancellation, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the cancellation, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/interrupt_task_request.json
+++ b/rmf_api_msgs/schemas/interrupt_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/interrupt_task_request.json
+++ b/rmf_api_msgs/schemas/interrupt_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the interruption",
+      "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/interrupt_task_request.json
+++ b/rmf_api_msgs/schemas/interrupt_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/kill_task_request.json
+++ b/rmf_api_msgs/schemas/kill_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the kill, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the kill, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/kill_task_request.json
+++ b/rmf_api_msgs/schemas/kill_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the kill",
+      "description": "Labels to describe the purpose of the kill, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/kill_task_request.json
+++ b/rmf_api_msgs/schemas/kill_task_request.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "labels": {
-      "description": "Labels to describe the purpose of the kill, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the kill, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/resume_task_request.json
+++ b/rmf_api_msgs/schemas/resume_task_request.json
@@ -21,7 +21,7 @@
       "uniqueItems": true
     },
     "labels": {
-      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/resume_task_request.json
+++ b/rmf_api_msgs/schemas/resume_task_request.json
@@ -21,7 +21,7 @@
       "uniqueItems": true
     },
     "labels": {
-      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/resume_task_request.json
+++ b/rmf_api_msgs/schemas/resume_task_request.json
@@ -21,7 +21,7 @@
       "uniqueItems": true
     },
     "labels": {
-      "description": "Labels describing this request",
+      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/skip_phase_request.json
+++ b/rmf_api_msgs/schemas/skip_phase_request.json
@@ -20,7 +20,7 @@
       "minimum": 0
     },
     "labels": {
-      "description": "Labels to describe the purpose of the skip, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the skip, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/skip_phase_request.json
+++ b/rmf_api_msgs/schemas/skip_phase_request.json
@@ -20,7 +20,7 @@
       "minimum": 0
     },
     "labels": {
-      "description": "Labels to describe the purpose of the skip, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the skip, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/skip_phase_request.json
+++ b/rmf_api_msgs/schemas/skip_phase_request.json
@@ -20,7 +20,7 @@
       "minimum": 0
     },
     "labels": {
-      "description": "Labels to describe the purpose of the skip",
+      "description": "Labels to describe the purpose of the skip, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/task_request.json
+++ b/rmf_api_msgs/schemas/task_request.json
@@ -22,7 +22,7 @@
       "description": "A description of the task. This must match a schema supported by a fleet for the category of this task request."
     },
     "labels": {
-      "description": "Labels to describe the purpose of the task dispatch request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the task dispatch request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     },

--- a/rmf_api_msgs/schemas/task_request.json
+++ b/rmf_api_msgs/schemas/task_request.json
@@ -22,7 +22,7 @@
       "description": "A description of the task. This must match a schema supported by a fleet for the category of this task request."
     },
     "labels": {
-      "description": "Labels to describe the purpose of the task dispatch request",
+      "description": "Labels to describe the purpose of the task dispatch request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     },

--- a/rmf_api_msgs/schemas/task_request.json
+++ b/rmf_api_msgs/schemas/task_request.json
@@ -22,7 +22,7 @@
       "description": "A description of the task. This must match a schema supported by a fleet for the category of this task request."
     },
     "labels": {
-      "description": "Labels to describe the purpose of the task dispatch request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels to describe the purpose of the task dispatch request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
       "type": "array",
       "items": { "type": "string" }
     },

--- a/rmf_api_msgs/schemas/task_state.json
+++ b/rmf_api_msgs/schemas/task_state.json
@@ -56,7 +56,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the cancel request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Labels to describe the cancel request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         }
@@ -72,7 +72,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the kill request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Labels to describe the kill request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         }
@@ -125,7 +125,7 @@
           ]
         },
         "labels": {
-          "description": "Information about how and why this task was booked, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Information about how and why this task was booked, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -219,7 +219,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -232,7 +232,7 @@
               "type": "integer"
             },
             "labels": {
-              "description": "Labels to describe the resume request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+              "description": "Labels to describe the resume request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
               "type": "array",
               "items": { "type": "string" }
             }
@@ -251,7 +251,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the purpose of the skip request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Labels to describe the purpose of the skip request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -264,7 +264,7 @@
               "type": "integer"
             },
             "labels": {
-              "description": "Labels to describe the undo skip request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+              "description": "Labels to describe the undo skip request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
               "type": "array",
               "items": { "type": "string" }
             }

--- a/rmf_api_msgs/schemas/task_state.json
+++ b/rmf_api_msgs/schemas/task_state.json
@@ -56,7 +56,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the cancel request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Labels to describe the cancel request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
           "type": "array",
           "items": { "type": "string" }
         }
@@ -72,7 +72,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the kill request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Labels to describe the kill request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
           "type": "array",
           "items": { "type": "string" }
         }
@@ -125,7 +125,7 @@
           ]
         },
         "labels": {
-          "description": "Information about how and why this task was booked, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Information about how and why this task was booked, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -219,7 +219,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -232,7 +232,7 @@
               "type": "integer"
             },
             "labels": {
-              "description": "Labels to describe the resume request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+              "description": "Labels to describe the resume request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
               "type": "array",
               "items": { "type": "string" }
             }
@@ -251,7 +251,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the purpose of the skip request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+          "description": "Labels to describe the purpose of the skip request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -264,7 +264,7 @@
               "type": "integer"
             },
             "labels": {
-              "description": "Labels to describe the undo skip request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+              "description": "Labels to describe the undo skip request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
               "type": "array",
               "items": { "type": "string" }
             }

--- a/rmf_api_msgs/schemas/task_state.json
+++ b/rmf_api_msgs/schemas/task_state.json
@@ -56,7 +56,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the cancel request",
+          "description": "Labels to describe the cancel request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         }
@@ -72,7 +72,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the kill request",
+          "description": "Labels to describe the kill request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         }
@@ -125,7 +125,7 @@
           ]
         },
         "labels": {
-          "description": "Information about how and why this task was booked",
+          "description": "Information about how and why this task was booked, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -219,7 +219,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the purpose of the interruption",
+          "description": "Labels to describe the purpose of the interruption, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -232,7 +232,7 @@
               "type": "integer"
             },
             "labels": {
-              "description": "Labels to describe the resume request",
+              "description": "Labels to describe the resume request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
               "type": "array",
               "items": { "type": "string" }
             }
@@ -251,7 +251,7 @@
           "type": "integer"
         },
         "labels": {
-          "description": "Labels to describe the purpose of the skip request",
+          "description": "Labels to describe the purpose of the skip request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
           "type": "array",
           "items": { "type": "string" }
         },
@@ -264,7 +264,7 @@
               "type": "integer"
             },
             "labels": {
-              "description": "Labels to describe the undo skip request",
+              "description": "Labels to describe the undo skip request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
               "type": "array",
               "items": { "type": "string" }
             }

--- a/rmf_api_msgs/schemas/undo_skip_phase_request.json
+++ b/rmf_api_msgs/schemas/undo_skip_phase_request.json
@@ -21,7 +21,7 @@
       "uniqueItems": true
     },
     "labels": {
-      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/undo_skip_phase_request.json
+++ b/rmf_api_msgs/schemas/undo_skip_phase_request.json
@@ -21,7 +21,7 @@
       "uniqueItems": true
     },
     "labels": {
-      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
+      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `app=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with an empty string value.",
       "type": "array",
       "items": { "type": "string" }
     }

--- a/rmf_api_msgs/schemas/undo_skip_phase_request.json
+++ b/rmf_api_msgs/schemas/undo_skip_phase_request.json
@@ -21,7 +21,7 @@
       "uniqueItems": true
     },
     "labels": {
-      "description": "Labels describing this request",
+      "description": "Labels describing this request, items can be a single value like `dashboard` or a key-value pair like `via=dashboard`, in the case of a single value, it will be interpreted as a key-value pair with `null` value.",
       "type": "array",
       "items": { "type": "string" }
     }


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## New feature implementation

### Implemented feature

Add documentation for how labels should be formatted.

### Implementation description

Currently in the `deploy/hammer` branch of rmf-web, we are abusing labels to store more helpful metadata by storing a json string. While it works, it is a very hacky approach and may break other frontends that expect the label to be formatted differently.

One problem of the current label "system" which forces us to abuse it is that it only allows storing a single value (it acts more like tags), so we can't store certain metadata like `pickup=<location>` and `destination=<location>` without introducing some kind of format to the label.

This PR basically aims to standardize how labels should be formatted to avoid such abuses and allow different frontends to be able to interpret it.

### Alternatives

#### Use a strict object type to represent key-value pairs

Instead of a free-form string, use something like `{ key: string, value: string }`, this breaks compatibility with current message schema, it also makes it more confusing to support both single value labels and key-value pair labels. It is also tempting to make it `{ key: string, value: any }`, which is probably a bad idea (nested labels, type coercion issues etc).

#### Introduce a new field for key-value labels

"labels" is more commonly used for key-value pairs and "tags" is more common for single value. Since we are already using "labels" for single value metadata, it can be confusing to introduce a new field.